### PR TITLE
correctly return the Count instead of the ThrottleCacheItem object

### DIFF
--- a/src/BrakePedal.Tests/MemoryThrottleRepositoryTests.cs
+++ b/src/BrakePedal.Tests/MemoryThrottleRepositoryTests.cs
@@ -61,6 +61,52 @@ namespace BrakePedal.Tests
                 Assert.Equal(2L, item.Count);
                 Assert.Equal(new DateTime(2030, 1, 1), item.Expiration);
             }
+
+
+            [Fact]
+            public void RetrieveValidThrottleCountFromRepostitory()
+            {
+                // Arrange
+                var key = new SimpleThrottleKey("test", "key");
+                var limiter = new Limiter()
+                    .Limit(1)
+                    .Over(100);
+                var cache = new MemoryCache("testing_cache");
+                var repository = new MemoryThrottleRepository(cache);
+                string id = repository.CreateThrottleKey(key, limiter);
+
+                var cacheItem = new MemoryThrottleRepository.ThrottleCacheItem()
+                {
+                    Count = 1,
+                    Expiration = new DateTime(2030, 1, 1)
+                };
+
+                repository.AddOrIncrementWithExpiration(key, limiter);
+
+                // Act
+                var count = repository.GetThrottleCount(key, limiter);
+
+                // Assert
+                Assert.Equal(count, 1);
+            }
+
+            [Fact]
+            public void ThrottleCountReturnsNullWhenUsingInvalidKey()
+            {
+                // Arrange
+                var key = new SimpleThrottleKey("test", "key");
+                var limiter = new Limiter()
+                    .Limit(1)
+                    .Over(100);
+                var cache = new MemoryCache("testing_cache");
+                var repository = new MemoryThrottleRepository(cache);
+
+                // Act
+                var count = repository.GetThrottleCount(key, limiter);
+
+                // Assert
+                Assert.Equal(count, null);
+            }
         }
 
         public class ThrottleCacheItemTests

--- a/src/BrakePedal/MemoryThrottleRepository.cs
+++ b/src/BrakePedal/MemoryThrottleRepository.cs
@@ -27,7 +27,14 @@ namespace BrakePedal
         public long? GetThrottleCount(IThrottleKey key, Limiter limiter)
         {
             string id = CreateThrottleKey(key, limiter);
-            return _store.Get(id) as long?;
+
+            var cacheItem = _store.Get(id) as ThrottleCacheItem;
+            if (cacheItem != null)
+            {
+                return cacheItem.Count;
+            }
+
+            return null;
         }
 
         public void AddOrIncrementWithExpiration(IThrottleKey key, Limiter limiter)


### PR DESCRIPTION
`GetThrottleCount()` in `MemortyThrottleRepostiory` was always returning null because it's trying to convert `ThrottleCacheItem` into a `long?`
